### PR TITLE
Add expand-selection and preserve selection after duplicate

### DIFF
--- a/duplicate-thing.el
+++ b/duplicate-thing.el
@@ -29,14 +29,10 @@
 
 ;;; Code:
 
-(defun duplicate-thing-line-start-p ()
-  "Return 't if current position is beginning of line."
-  (= 0 (current-column)))
-
 (defun duplicate-thing-line-start-after-forward-line-p ()
   "Return 't if the position is beginning of line after foward-line."
   (forward-line)
-  (duplicate-thing-line-start-p))
+  (= 0 (current-column)))
 
 (defun duplicate-thing-expand-selection (p1 p2)
   "Expand selection to contain while lines.

--- a/duplicate-thing.el
+++ b/duplicate-thing.el
@@ -36,27 +36,29 @@
   (forward-line)
   (= 0 (current-column)))
 
+(defun duplicate-thing-select-current-line ()
+  "Select current line."
+  (let (start end)
+    (beginning-of-line)
+    (setq start (point))
+    (unless (duplicate-thing-line-start-after-forward-line-p) (newline))
+    (setq end (point))
+    (setq deactivate-mark nil)
+    (set-mark start)))
+
 (defun duplicate-thing-expand-selection ()
   "Expand selection to contain whole lines."
   (let ((start (region-beginning))
         (end   (region-end)))
-    (message (format "%d, %d" start end))
-    (cond (mark-active
-           (goto-char start)
-           (beginning-of-line)
-           (setq start (point))
-           (goto-char end)
-           (unless (= 0 (current-column))
-             (unless (duplicate-thing-line-start-after-forward-line-p)
-               (newline)))
-           (setq end (point)))
-          (t
-           (beginning-of-line)
-           (setq start (point))
-           (unless (duplicate-thing-line-start-after-forward-line-p) (newline))
-           (setq end (point))))
-    (setq deactivate-mark nil)
+    (goto-char start)
+    (beginning-of-line)
+    (setq start (point))
     (goto-char end)
+    (unless (= 0 (current-column))
+      (unless (duplicate-thing-line-start-after-forward-line-p)
+        (newline)))
+    (setq end (point))
+    (setq deactivate-mark nil)
     (set-mark start)))
 
 (defun duplicate-thing-at (p text n)
@@ -71,7 +73,9 @@
 If it has active mark (P1, P2), it will expand the selection and duplicate it.
 If it doesn't have active mark, it will select current line and duplicate it."
   (interactive "P")
-  (duplicate-thing-expand-selection)
+  (if mark-active
+      (duplicate-thing-expand-selection)
+    (duplicate-thing-select-current-line))
   (let (p1 p2 len text with-comment-out)
     (setq p1   (region-beginning)
           p2   (region-end)

--- a/duplicate-thing.el
+++ b/duplicate-thing.el
@@ -70,7 +70,7 @@
 ;;;###autoload
 (defun duplicate-thing (n)
   "Duplicate line or region N times.
-If it has active mark (P1, P2), it will expand the selection and duplicate it.
+If it has active mark, it will expand the selection and duplicate it.
 If it doesn't have active mark, it will select current line and duplicate it."
   (interactive "P")
   (if mark-active


### PR DESCRIPTION
I update the change to embrace your comment out function. The main changes are:
* Expand selection to include whole lines.
* Preserve selection after duplicate. You can duplicate the same thing repeatedly very easily. This is useful as you might not want to think how many times you want to repeat before duplication. You can just repeat the bound keys (M-c) as many times as you want.

Please take a look. Thanks.