### PR TITLE
Make duplicate things behave more predictably compared to other editors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,17 @@ GPLv3
 (auto-install-from-url "https://raw.github.com/ongaeshi/duplicate-thing/master/duplicate-thing.el")
 ```
 
+### Install with `straight.el` and `use-package`
+
+```emacs-lisp
+(straight-use-package '(duplicate-thing :type git :host github :repo "ongaeshi/duplicate-thing"))
+
+(use-package duplicate-thing
+  :bind
+  ("M-c" . duplicate-thing))
+```
+
+
 ## .emacs.d/init.el
 
 ```emacs-lisp

--- a/duplicate-thing.el
+++ b/duplicate-thing.el
@@ -31,20 +31,12 @@
 
 ;;; Code:
 
-(defun duplicate-thing-line-start-after-forward-line-p ()
-  "Return 't if the position is beginning of line after foward-line."
-  (forward-line)
-  (= 0 (current-column)))
-
 (defun duplicate-thing-select-current-line ()
-  "Select current line."
-  (let (start end)
+  "Select current line and keep a mark on it."
     (beginning-of-line)
-    (setq start (point))
-    (unless (duplicate-thing-line-start-after-forward-line-p) (newline))
-    (setq end (point))
-    (setq deactivate-mark nil)
-    (set-mark start)))
+    (push-mark (point) t t)
+    (end-of-line)
+    (setq deactivate-mark nil))
 
 (defun duplicate-thing-expand-selection ()
   "Expand selection to contain whole lines."
@@ -52,19 +44,16 @@
         (end   (region-end)))
     (goto-char start)
     (beginning-of-line)
-    (setq start (point))
+    (push-mark (point) t t)
     (goto-char end)
-    (unless (= 0 (current-column))
-      (unless (duplicate-thing-line-start-after-forward-line-p)
-        (newline)))
-    (setq end (point))
-    (setq deactivate-mark nil)
-    (set-mark start)))
+    (end-of-line)
+    (setq deactivate-mark nil)))
 
 (defun duplicate-thing-at (p text n)
   "Duplicate TEXT N times at P."
+  (newline)
+  (push-mark (point) t t)
   (dotimes (i (or n 1)) (insert text))
-  (set-mark p)
   (setq deactivate-mark nil))
 
 ;;;###autoload
@@ -86,7 +75,7 @@ If it doesn't have active mark, it will select current line and duplicate it."
         (progn
           (comment-region p1 p2)
           (duplicate-thing-at (point) text 1))
-      (duplicate-thing-at p2 text n)))
+      (duplicate-thing-at  p2 text n)))
   (setq transient-mark-mode (cons 'only t)))
 
 (provide 'duplicate-thing)


### PR DESCRIPTION
## Reason for change

If you duplicate smth you often want to move it.  Currently, the point is moved beyond duplicated snipped which makes immediate use of commands to move the snipped also touches adjacent text from the line where the point is.

## What was updated

The logic was improved to limit the selection after duplication to only duplicated text.
`push-mark` is used instead of `set-mark` for better compatibility as recommended by the Emacs manual.

```
set-mark is a compiled Lisp function in ‘simple.el’.

(set-mark POS)

Set this buffer’s mark to POS.  Don’t use this function!
That is to say, don’t use this function unless you want
the user to see that the mark has moved, and you want the previous
mark position to be lost.

Normally, when a new mark is set, the old one should go on the stack.
This is why most applications should use ‘push-mark’, not ‘set-mark’.

Novice Emacs Lisp programmers often try to use the mark for the wrong
purposes.  The mark saves a location for the user’s convenience.
Most editing commands should not alter the mark.
To remember a location for internal use in the Lisp program,
store it in a Lisp variable.  Example:

   (let ((beg (point))) (forward-line 1) (delete-region beg (point))).
```

## Screenshots

### Region

![image](https://user-images.githubusercontent.com/10460752/107156775-95823180-6980-11eb-8487-eea55bbecfd4.png)
![image](https://user-images.githubusercontent.com/10460752/107156779-9adf7c00-6980-11eb-963c-2f9a57a2dfbd.png)

### Line

![image](https://user-images.githubusercontent.com/10460752/107156846-f7429b80-6980-11eb-834c-96d44870a28a.png)
![image](https://user-images.githubusercontent.com/10460752/107156929-73d57a00-6981-11eb-821a-28eb66a0dc52.png)

## Tests
I've manually tested for a couple of days. You can install it from my fork if you'd like to test yourself.

Cheers!


